### PR TITLE
Permite extrair informações adicionais de disciplinas, como carga horária

### DIFF
--- a/db/migrate/20171203030640_add_curriculum_to_disciplines.rb
+++ b/db/migrate/20171203030640_add_curriculum_to_disciplines.rb
@@ -1,0 +1,5 @@
+class AddCurriculumToDisciplines < ActiveRecord::Migration[5.0]
+  def change
+    add_column :disciplines, :curriculum, :string
+  end
+end

--- a/db/migrate/20171203165136_add_load_to_disciplines.rb
+++ b/db/migrate/20171203165136_add_load_to_disciplines.rb
@@ -1,0 +1,5 @@
+class AddLoadToDisciplines < ActiveRecord::Migration[5.0]
+  def change
+    add_column :disciplines, :load, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012173627) do
+ActiveRecord::Schema.define(version: 20171203030640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20161012173627) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_disciplines_on_code", using: :btree
+    t.string   "curriculum"
   end
 
   create_table "pre_requisites", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171203030640) do
+ActiveRecord::Schema.define(version: 20171203165136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,8 +66,9 @@ ActiveRecord::Schema.define(version: 20171203030640) do
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["code"], name: "index_disciplines_on_code", using: :btree
     t.string   "curriculum"
+    t.integer  "load"
+    t.index ["code"], name: "index_disciplines_on_code", using: :btree
   end
 
   create_table "pre_requisites", force: :cascade do |t|

--- a/lib/tasks/crawler.rake
+++ b/lib/tasks/crawler.rake
@@ -37,7 +37,7 @@ namespace :crawler do
 
 
   desc 'Crawl the disciplines of every known course'
-  task :disciplines => [:environment, :courses] do
+  task :disciplines => :environment do
     puts '-----------------------------------------------------------------------'
     puts '-> Starting disciplines crawling...'
 

--- a/lib/tasks/crawler.rake
+++ b/lib/tasks/crawler.rake
@@ -37,7 +37,7 @@ namespace :crawler do
 
 
   desc 'Crawl the disciplines of every known course'
-  task :disciplines => :environment do
+  task :disciplines => [:environment, :courses] do
     puts '-----------------------------------------------------------------------'
     puts '-> Starting disciplines crawling...'
 
@@ -66,12 +66,19 @@ namespace :crawler do
           name = columns[3].css('a').text.strip
           name = columns[3].text.strip if name == ""
 
+          curriculum = nil
+          discipline_link = columns[3].css('a')
+          if discipline_link.size == 1 && discipline_link.first.attr('href') =~ /nuPerInicial=(\d+)/
+            curriculum = $1
+          end
+
           discipline = Discipline.find_by_code code
 
           unless discipline
             discipline = Discipline.new
             discipline.code = code
             discipline.name = name
+            discipline.curriculum = curriculum
             discipline.save
           end
 

--- a/lib/tasks/crawler.rake
+++ b/lib/tasks/crawler.rake
@@ -98,6 +98,27 @@ namespace :crawler do
     puts '-----------------------------------------------------------------------'
   end
 
+  desc 'Crawl discipline info'
+  task :discipline_infos => :environment do
+    puts '-----------------------------------------------------------------------'
+    puts '-> Starting disciplines info crawling...'
+
+    require 'rubygems'
+    require 'mechanize'
+
+    Discipline.all.order(:name).each do |discipline|
+      puts "    Crawling #{discipline.code} - #{discipline.name}"
+
+      agent = Mechanize.new
+      hub = agent.get "https://alunoweb.ufba.br/SiacWWW/ExibirEmentaPublico.do?cdDisciplina=#{discipline.code}&nuPerInicial=#{discipline.curriculum}"
+
+      body = hub.body.force_encoding("iso-8859-1").encode('utf-8')
+      if body =~ /Carga Hor.ria - Total: (\d+) horas/
+        discipline.load = $1.to_i
+        discipline.save
+      end
+    end
+  end
 
   desc 'Crawl the disciplines of every known course'
   task :pre_requisites => :environment do


### PR DESCRIPTION
Adicionei uma task ao crawler para extrair informações das páginas das disciplinas. Atualmente a única informação extraída é a carga horária, mas nas páginas há outras informações, como ementa e departamento.

Eu precisei dessa informação pra usar em uma aplicação que está sendo desenvolvida em uma disciplina. Não adicionei uma action no `AdminController` e nem uma rota em `config/routes.rb` porque minha necessidade é usar apenas como rake task.

Se eu fiz tudo certo, as mudanças não devem ter impacto sobre a aplicação web.