### PR TITLE
Removed assets volume that overwrote new assets

### DIFF
--- a/deploy/nginx/Dockerfile
+++ b/deploy/nginx/Dockerfile
@@ -1,2 +1,4 @@
 FROM nginx:1.21.6-alpine
 COPY nginx.conf /etc/nginx/nginx.conf
+
+COPY --from=app /app/public /app/public

--- a/deploy/nginx/Dockerfile
+++ b/deploy/nginx/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.21.6-alpine
 COPY nginx.conf /etc/nginx/nginx.conf
 
-COPY --from=app /app/public /app/public
+COPY --from=meuhorario2_web:latest /app/public /app/public

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,6 @@ services:
       - "443:443"
     volumes:
       - /etc/letsencrypt:/app/letsencrypt
-      - assets:/app/public
     restart: unless-stopped
 
   web:
@@ -25,8 +24,6 @@ services:
     env_file: deploy/web/.env.prod
     depends_on:
       - database
-    volumes:
-      - assets:/app/public
     networks:
       - overlay
       - db_network
@@ -44,7 +41,6 @@ services:
 
 volumes:
   pg_data:
-  assets:
 
 networks:
   overlay:


### PR DESCRIPTION
Assets were being precompiled in docker build but they were being overwritten by the previous assets since there was a volume shared between web and nginx containers associated to the same assets folder.

This removes that volume and changes the method of sharing assets between containers. Now nginx container copies the assets from the built web container and nothing is shared between them when running anymore.