### PR TITLE
Adds tons of visibility and error handling to scrapers

### DIFF
--- a/app/lib/concurrent_runner.rb
+++ b/app/lib/concurrent_runner.rb
@@ -5,7 +5,7 @@ class ConcurrentRunner
   def initialize(queue: Queue.new, threads: 1)
     @queue = queue
     @thread_number = threads
-    @progress_bar = ProgressBar.create(total: @queue.size)
+    @progress_bar = ProgressBar.create(total: @queue.size, format: '%t: %B | %c / %C | %E')
   end
 
   # Spawns 'thread_number' threads to concurrently run a method of an object
@@ -16,24 +16,50 @@ class ConcurrentRunner
     threads.map(&:join)
   end
 
+  private
+
   # Spawns a thread that runs 'object.method_name' in the 'queue'
   def spawn_thread(object, method_name)
-    retries = 3
+    dead_iterations = []
 
     Thread.new do
       while (args = @queue.pop(true))
-        object.send(method_name, *args)
-        @progress_bar.increment
-      end
-    rescue Net::OpenTimeout
-      retries -= 1
+        retries = 3
 
-      if retries > 0
-        sleep 10
-        retry
+        begin
+          object.send(method_name, *args)
+          @progress_bar.increment
+        rescue StandardError => e
+          print_iteration_error(e, retries)
+          retries -= 1
+
+          if retries > 0
+            sleep 10
+            retry
+          else
+            dead_iterations << args_to_s(args)
+          end
+        end
       end
     rescue ThreadError
-      nil
+      puts "\n\nDEAD ITERATIONS: #{dead_iterations.pretty_inspect}\n\n" if dead_iterations.any?
     end
+  end
+
+  def print_iteration_error(error, retries)
+    puts "====> Error in thread ##{Thread.current.object_id}! [#{retries} retries remaining]"
+    puts error.message
+  end
+
+  def args_to_s(args)
+    args.map! do |arg|
+      case arg
+      when ApplicationRecord
+        "#{arg.class}[#{arg.id}]"
+      else arg.to_s
+      end
+    end
+
+    args.join(', ')
   end
 end

--- a/app/lib/scrapers/discipline_infos.rb
+++ b/app/lib/scrapers/discipline_infos.rb
@@ -38,7 +38,7 @@ module Scrapers
       body = info_page.body
       hours = body.match(/Carga Hor.ria - Total: (\d+) horas/)&.captures&.first
 
-      discipline.update(hours:)
+      discipline.update(hours:) if hours
     end
   end
 end

--- a/app/lib/scrapers/disciplines.rb
+++ b/app/lib/scrapers/disciplines.rb
@@ -47,7 +47,8 @@ module Scrapers
       rows.each do |row|
         semester, nature, code, name, curriculum = discipline_row_data(row)
 
-        semester ||= current_semester if nature == 'OB'
+        semester   ||= current_semester if nature == 'OB'
+        curriculum ||= course.curriculum
         current_semester = semester
 
         discipline = store_discipline(code, name, curriculum)

--- a/app/lib/scrapers/pre_requisites.rb
+++ b/app/lib/scrapers/pre_requisites.rb
@@ -48,6 +48,8 @@ module Scrapers
         code, pre_requisite_text = discipline_row_data(row)
         pre_requisite_codes = parse_pre_requisite_text(pre_requisite_text, previous_codes)
 
+        next if pre_requisite_codes.blank?
+
         course_discipline = find_course_discipline(course, code)
         store_pre_requisites(course_discipline, pre_requisite_codes)
 
@@ -85,10 +87,7 @@ module Scrapers
 
     # Finds a course_discipline object by passing the course model and the discipline code
     def find_course_discipline(course, code)
-      CourseDiscipline.find_by(
-        course:,
-        discipline: Discipline.where(code:)
-      )
+      course.course_disciplines.find_by(discipline: Discipline.where(code:))
     end
 
     # Stores the pre requisites of the course discipline

--- a/app/models/discipline.rb
+++ b/app/models/discipline.rb
@@ -4,4 +4,5 @@ class Discipline < ApplicationRecord
   has_many :discipline_classes, dependent: :destroy
 
   validates :code, presence: true, uniqueness: true
+  validates :curriculum, presence: true
 end

--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -1,12 +1,14 @@
 namespace :scraper do
   desc 'Runs all scraper tasks in sequence'
-  task all: :environment do
+  task :all, [:threads] => [:environment] do |_, args|
+    threads = args[:threads]&.to_i || default_thread_count
+
     Rake::Task['scraper:courses'].invoke
-    Rake::Task['scraper:areas'].invoke
-    Rake::Task['scraper:disciplines'].invoke
-    Rake::Task['scraper:pre_requisites'].invoke
-    Rake::Task['scraper:classes'].invoke
-    Rake::Task['scraper:discipline_infos'].invoke
+    Rake::Task['scraper:areas'].invoke(threads)
+    Rake::Task['scraper:disciplines'].invoke(threads)
+    Rake::Task['scraper:pre_requisites'].invoke(threads)
+    Rake::Task['scraper:classes'].invoke(threads)
+    Rake::Task['scraper:discipline_infos'].invoke(threads)
   end
 
   desc 'Scrapes courses info from a public courses list'
@@ -17,30 +19,34 @@ namespace :scraper do
     courses = courses_scraper.scrape
 
     puts "    #{courses} courses found"
+    puts '      of ~118 expected'
+
     puts '-> Finished'
   end
 
   desc 'Scrapes course areas from SUPAC'
-  task areas: :environment do
-    processor_cores = `grep -c processor /proc/cpuinfo`.to_i
-    threads = [4, processor_cores].min
+  task :areas, [:threads] => [:environment] do |_, args|
+    threads = args[:threads]&.to_i || default_thread_count
 
     puts '-> Starting areas scraping...'
 
     areas_scraper = Scrapers::Areas.new(threads:)
     areas = areas_scraper.scrape
 
+    puts "    #{areas} areas found"
+    puts '      of 8 expected'
+
     orphan_courses = Course.where(area: nil)
 
-    puts "    #{areas} areas found"
     puts "    #{orphan_courses.size} orphan courses remain"
+    puts '      of 0 expected'
+
     puts '-> Finished'
   end
 
   desc 'Scrape the disciplines of every known course'
-  task disciplines: :environment do
-    processor_cores = `grep -c processor /proc/cpuinfo`.to_i
-    threads = [4, processor_cores].min
+  task :disciplines, [:threads] => [:environment] do |_, args|
+    threads = args[:threads]&.to_i || default_thread_count
 
     puts '-> Starting disciplines scraping...'
 
@@ -48,13 +54,24 @@ namespace :scraper do
     disciplines = disciplines_scraper.scrape
 
     puts "    #{disciplines} disciplines found"
+    puts '      of ~6200 expected'
+
+    course_disciplines = CourseDiscipline.all
+
+    puts "    #{course_disciplines.size} course disciplines found"
+    puts '      of ~12211 expected'
+
+    courses_without_disciplines = Course.where.not(id: CourseDiscipline.select(:course_id))
+
+    puts "    #{courses_without_disciplines.size} courses without disciplines found"
+    puts '      of 0 expected'
+
     puts '-> Finished'
   end
 
   desc 'Crawl the disciplines of every known course'
-  task pre_requisites: :environment do
-    processor_cores = `grep -c processor /proc/cpuinfo`.to_i
-    threads = [4, processor_cores].min
+  task :pre_requisites, [:threads] => [:environment] do |_, args|
+    threads = args[:threads]&.to_i || default_thread_count
 
     puts '-> Starting pre requisites scraping...'
 
@@ -62,13 +79,22 @@ namespace :scraper do
     pre_requisites = pre_requisites_scraper.scrape
 
     puts "    #{pre_requisites} pre requisite links between disciplines"
+    puts '      of ~7754 expected'
+
+    pre_disciplines  = CourseDiscipline.where(id: PreRequisite.select(:pre_discipline_id))
+    post_disciplines = CourseDiscipline.where(id: PreRequisite.select(:post_discipline_id))
+    course_disciplines         = pre_disciplines.or(post_disciplines)
+    courses_without_requisites = Course.where.not(id: course_disciplines.select(:course_id))
+
+    puts "    #{courses_without_requisites.size} courses without pre requisites found"
+    puts '      of ~15 expected'
+
     puts '-> Finished'
   end
 
   desc 'Scrape additional infos for every known discipline'
-  task discipline_infos: :environment do
-    processor_cores = `grep -c processor /proc/cpuinfo`.to_i
-    threads = [4, processor_cores].min
+  task :discipline_infos, [:threads] => [:environment] do |_, args|
+    threads = args[:threads]&.to_i || default_thread_count
 
     puts '-> Starting discipline infos scraping...'
 
@@ -76,13 +102,19 @@ namespace :scraper do
     updated_disciplines = discipline_infos_scraper.scrape
 
     puts "    #{updated_disciplines} disciplines with hours"
+    puts '      of ~5687 expected'
+
+    disciplines_without_hours = Discipline.where(hours: nil)
+
+    puts "    #{disciplines_without_hours.size} disciplines without hours"
+    puts '      of ~512 expected'
+
     puts '-> Finished'
   end
 
   desc 'Scrape classes and schedule from the SUPAC schedule guides'
-  task classes: :environment do
-    processor_cores = `grep -c processor /proc/cpuinfo`.to_i
-    threads = [4, processor_cores].min
+  task :classes, [:threads] => [:environment] do |_, args|
+    threads = args[:threads]&.to_i || default_thread_count
 
     puts '-> Starting classes scraping...'
 
@@ -90,6 +122,45 @@ namespace :scraper do
     discipline_classes = classes_scraper.scrape
 
     puts "    #{discipline_classes} classes found"
+    puts '      of ~8857 expected'
+
+    discipline_offers = DisciplineClassOffer.all
+
+    puts "    #{discipline_offers.size} discipline offers found"
+    puts '      of ~8924 expected'
+
+    course_offers = CourseClassOffer.all
+
+    puts "    #{course_offers.size} course offers found"
+    puts '      of ~16414 expected'
+
+    disciplines_without_classes = Discipline.where.not(id: DisciplineClass.select(:discipline_id))
+
+    puts "    #{disciplines_without_classes.size} disciplines without classes found"
+    puts '      of ~3162 expected'
+
+    courses_without_classes = Course.where.not(id: CourseClassOffer.select(:course_id))
+
+    puts "    #{courses_without_classes.size} courses without classes found"
+    puts '      of ~11 expected'
+
+    schedules = Schedule.all
+
+    puts "    #{schedules.size} schedules found"
+    puts '      of ~15160 expected'
+
+    professors = Professor.all
+
+    puts "    #{professors.size} professors found"
+    puts '      of ~2498 expected'
+
     puts '-> Finished'
+  end
+
+  ### HELPERS ###
+
+  def default_thread_count
+    processor_cores = `grep -c processor /proc/cpuinfo`.to_i
+    [4, processor_cores].min
   end
 end

--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -107,7 +107,7 @@ namespace :scraper do
     disciplines_without_hours = Discipline.where(hours: nil)
 
     puts "    #{disciplines_without_hours.size} disciplines without hours"
-    puts '      of ~512 expected'
+    puts '      of ~334 expected'
 
     puts '-> Finished'
   end


### PR DESCRIPTION
Changes to scrapers:
- Improved progress bar;
- Improved error messages during execution;
- Moved thread retry to be per-iteration (from the queue) instead of per-thread;
- At the end of execution, prints iterations that failed (after 3 retries);
- Added `threads` argument to scraper rake tasks;
- Added tons of logs after the rake tasks finish scraping. Includes current and expected values;

Other improvements:
- Prevents disciplines being created without curriculum;