### PR TITLE
Fixes bug with multiple guides for the same course

### DIFF
--- a/app/lib/scrapers/classes.rb
+++ b/app/lib/scrapers/classes.rb
@@ -57,7 +57,9 @@ module Scrapers
       end
 
       guide_uris = guide_links.map { |a| URI.join(BASE_URI, a['href']).to_s }
-      guide_uris.select { |uri| uri.include? '/sites/supac.ufba.br/files/' }
+      guide_uris = guide_uris.select { |uri| uri.include? '/sites/supac.ufba.br/files/' }
+
+      guide_uris.uniq
     end
 
     # Scrapes a course guide, storing the informations


### PR DESCRIPTION
Some courses in the guides hub in SUPAC have multiple guides linked.
![image](https://github.com/user-attachments/assets/5ec6ea1c-6a6f-4a62-b85d-856252090149)

This prevents old guides from being scraped by checking their semester with the semester in the guide hub page.
Also removes duplicate guide uris to prevent scraping them again.